### PR TITLE
Update svg2ttf and freeze timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bufferstreams": "1.0.1",
     "gulp-util": "~3.0.3",
     "readable-stream": "^1.0.33",
-    "svg2ttf": "~1.2.0"
+    "svg2ttf": "^2.0.0"
   },
   "keywords": [
     "gulpplugin",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function svg2ttfTransform(opt) {
 
     // Use the buffered content
       try {
-        buf = new Buffer(svg2ttf(String(buf)).buffer);
+        buf = new Buffer(svg2ttf(String(buf), {ts: 0}).buffer);
         cb(null, buf);
       } catch(err) {
         cb(new gutil.PluginError(PLUGIN_NAME, err, {showStack: true}));
@@ -35,7 +35,7 @@ function svg2ttfGulp(options) {
   options.clone = options.clone || false;
 
   var stream = Stream.Transform({objectMode: true});
-  
+
   stream._transform = function(file, unused, done) {
      // When null just pass through
     if(file.isNull()) {
@@ -69,9 +69,9 @@ function svg2ttfGulp(options) {
     // Buffers
     if(file.isBuffer()) {
       try {
-        file.contents = new Buffer(svg2ttf(String(file.contents)).buffer);
+        file.contents = new Buffer(svg2ttf(String(file.contents), {ts: 0}).buffer);
       } catch(err) {
-        stream.emit('error', 
+        stream.emit('error',
           new gutil.PluginError(PLUGIN_NAME, err, {showStack: true}));
       }
 
@@ -83,7 +83,7 @@ function svg2ttfGulp(options) {
     stream.push(file);
     done();
   };
-  
+
   return stream;
 
 };


### PR DESCRIPTION
The TTF spec requires that a timestamp be embedded in each file. `svg2ttf` follows this and generates a new one every time it compiles a new file. This is problematic for caching based on file contents. Even if no source files change, the bytes in the created ttf file will (because of the changed timestamp). A `ts` option was recently added, enabling us to specify a static timestamp to prevent this.

**This isn't passing the tests** . There seems to be a breaking change in `svg2ttf` 2.0.0, and I'm not sure what's different. So that needs fixing, but I at least wanted to get the ball rolling. Getting this update in (and updating gulp-iconfont) means I could cut [this ugly workaround!](https://github.com/greypants/gulp-starter/blob/2.0/gulpfile.js/tasks/rev/rev-iconfont-workaround.js)

Thanks for putting all this together!