### PR TITLE
Replace gulp util

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "bufferstreams": "^1.1.0",
-    "gulp-util": "^3.0.7",
     "plugin-error": "^1.0.1",
     "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "istanbul": "^0.4.0",
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.0.0",
-    "streamtest": "^1.2.1"
+    "streamtest": "^1.2.1",
+    "vinyl": "^2.2.0"
   },
   "keywords": [
     "gulpplugin",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bufferstreams": "^1.1.0",
     "gulp-util": "^3.0.7",
     "readable-stream": "^2.0.4",
+    "replace-ext": "^1.0.0",
     "svg2ttf": "^4.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "bufferstreams": "^1.1.0",
     "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
     "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",
     "svg2ttf": "^4.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const Stream = require('readable-stream');
 const gutil = require('gulp-util');
+const replaceExt = require('replace-ext');
 const BufferStreams = require('bufferstreams');
 const svg2ttf = require('svg2ttf');
 
@@ -79,7 +80,7 @@ function svg2ttfGulp(options) {
       }
     }
 
-    file.path = gutil.replaceExtension(file.path, '.ttf');
+    file.path = replaceExt(file.path, '.ttf');
 
     // Buffers
     if(file.isBuffer()) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const Stream = require('readable-stream');
-const gutil = require('gulp-util');
+const PluginError = require('plugin-error');
 const replaceExt = require('replace-ext');
 const BufferStreams = require('bufferstreams');
 const svg2ttf = require('svg2ttf');
@@ -16,7 +16,7 @@ function svg2ttfTransform(options) {
 
     // Handle any error
     if(err) {
-      cb(new gutil.PluginError(PLUGIN_NAME, err, { showStack: true }));
+      cb(new PluginError(PLUGIN_NAME, err, { showStack: true }));
       return;
     }
 
@@ -28,7 +28,7 @@ function svg2ttfTransform(options) {
         version: options.version,
       }).buffer);
     } catch (err2) {
-      cb(new gutil.PluginError(PLUGIN_NAME, err2, { showStack: true }));
+      cb(new PluginError(PLUGIN_NAME, err2, { showStack: true }));
       return;
     }
     cb(null, buf);
@@ -92,7 +92,7 @@ function svg2ttfGulp(options) {
         }).buffer);
       } catch (err) {
         stream.emit('error',
-          new gutil.PluginError(PLUGIN_NAME, err, { showStack: true }));
+          new PluginError(PLUGIN_NAME, err, { showStack: true }));
       }
 
     // Streams

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -294,7 +294,7 @@ describe('gulp-svg2ttf conversion', function() {
                 }
                 assert.equal(objs.length, 1);
                 assert.equal(objs[0].path, 'bibabelula.foo');
-                assert(objs[0].contents instanceof Stream.PassThrough);
+                assert(objs[0].contents instanceof Stream);
                 done();
               })
             );

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const gulp = require('gulp');
-const gutil = require('gulp-util');
+const Vinyl = require('vinyl');
 const Stream = require('stream');
 const fs = require('fs');
 const path = require('path');
@@ -30,7 +30,7 @@ describe('gulp-svg2ttf conversion', function() {
         it('should let null files pass through', function(done) {
 
           StreamTest[version]
-            .fromObjects([new gutil.File({
+            .fromObjects([new Vinyl({
               path: 'bibabelula.foo',
               contents: null,
             })])
@@ -155,7 +155,7 @@ describe('gulp-svg2ttf conversion', function() {
 
         it('should let non-svg files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: Buffer.from('ohyeah'),
           })])
@@ -279,7 +279,7 @@ describe('gulp-svg2ttf conversion', function() {
 
         it('should let non-svg files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: new Stream.PassThrough(),
           })])


### PR DESCRIPTION
Connects #16 

replace deprecated sub-dependency gulp-util - followed the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5